### PR TITLE
feat: hold npm updates for three days

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ You can use it by specifying `github>the-unicorns/renovate-config` in the extend
 }
 ```
 
+## Release age
+
+npm updates are held back for three days via
+[`security:minimumReleaseAgeNpm`](https://docs.renovatebot.com/presets-security/#securityminimumreleaseagenpm),
+which leaves room for a malicious or broken release to be caught and unpublished
+before a PR ever opens. It also keeps Renovate's PRs clear of pnpm 11's own
+one-day `minimumReleaseAge` default, which otherwise rejects the lockfile at
+install time.
+
+To opt a dependency out, set `minimumReleaseAge` to `null` in a package rule.
+
 ## Contributing
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/basic.test.js
+++ b/basic.test.js
@@ -9,6 +9,7 @@ const renovatePkgExtends = pkgJson.extends;
 
 const baseRules = [
   "config:recommended",
+  "security:minimumReleaseAgeNpm",
   ":dependencyDashboard",
   ":dependencyDashboardApproval",
   ":labels(renovate, dependencies)",

--- a/default.json
+++ b/default.json
@@ -2,6 +2,7 @@
   "description": "The Unicorns Renovate Shareable Config",
   "extends": [
     "config:recommended",
+    "security:minimumReleaseAgeNpm",
     ":dependencyDashboard",
     ":dependencyDashboardApproval",
     ":labels(renovate, dependencies)",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,5 +5,3 @@ allowBuilds:
   dtrace-provider: true
   protobufjs: true
   re2: true
-minimumReleaseAgeExclude:
-  - renovate@44.13.1 || 44.14.10


### PR DESCRIPTION
## Why

pnpm 11 [turned supply-chain protection on by default](https://pnpm.io/v/11.0): `minimumReleaseAge` now defaults to 1440 minutes (1 day). Nothing in this repo sets it, so we inherit that default via the pinned `pnpm@11.20.0`.

Renovate opens PRs the moment a release lands, so every bump of the `renovate` dev dependency showed up inside that window and `pnpm install` refused the lockfile. Most recently #146 (`renovate` 44.14.10 → 44.17.3), whose CI ran at `08:51:42Z` against a version published at `08:21:21Z` — 30 minutes into a 24-hour hold:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification:
  renovate@44.17.3 was published at 2026-08-10T08:21:21.000Z, within the
  minimumReleaseAge cutoff (2026-08-09T08:51:34.145Z)
```

The workaround so far was a hand-maintained allowlist in `pnpm-workspace.yaml`:

```yaml
minimumReleaseAgeExclude:
  - renovate@44.13.1 || 44.14.10
```

Those two versions are the fossils of the two previous times this happened. Renovate has no idea the list exists, so it needed a manual entry on every bump.

## What

Extend [`security:minimumReleaseAgeNpm`](https://docs.renovatebot.com/presets-security/#securityminimumreleaseagenpm) — a 3-day hold on npm updates. PRs then arrive already clear of pnpm's 1-day window, and the exclude list has nothing left to do, so it's deleted.

- `default.json` — add the preset
- `basic.test.js` — add it to `baseRules`; the bidirectional `deepEqual` from #150 failed on the config before it was changed
- `pnpm-workspace.yaml` — drop `minimumReleaseAgeExclude`
- `README.md` — document the delay, since it changes behaviour downstream

## Verification

```
$ pnpm install
✓ Lockfile passes supply-chain policies (676 entries in 2.3s)

$ pnpm test
1..11
# pass  11
```

The full lockfile passes the policy with **no** exclusions, confirming the allowlist was only ever covering the freshness window. The lockfile itself is unchanged.

## Notes

- `feat:` rather than `fix:`, so release-please cuts a minor — this slows updates for every consumer of the shared config, not just this repo.
- The preset covers the **npm datasource only**. GitHub Actions bumps stay un-delayed; happy to widen it if that's wanted.
- #146 doesn't depend on this. 44.17.3 clears pnpm's window at `2026-08-11T08:21Z` — re-run the job after that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)